### PR TITLE
Add `Conditionable` support

### DIFF
--- a/src/MetadataDirector.php
+++ b/src/MetadataDirector.php
@@ -13,6 +13,7 @@ use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Conditionable;
 use RuntimeException;
 
 use function array_filter;
@@ -25,6 +26,7 @@ use function view;
 
 final class MetadataDirector implements BuildsMetadata
 {
+    use Conditionable;
     use HasDefaults;
 
     use HasConfig {


### PR DESCRIPTION
I ran into a situation where I wanted to conditionally apply an SEO image to override a default I set elsewhere:

```php
// AppServiceProvider.php
seo()->title('My title')->images($defaultImage);

// some-template.blade.php
seo()->title('Title override')->images($overrideImage);
```

However, my `$overrideImage` may not be available, in which case I'd like to keep using the default. Setting `$overrideImage` to `null` ends up clearing out the default, so I need to conditionally call the `->images()` method:

```php
seo()->title('Title override');
if ($overrideImage) {
    seo()->images($overrideImage);
}
```

That works fine, but Laravel's `Conditionable` trait provides `->when()` and `->unless()` methods, which can be very useful in fluent objects like the `MetadataDirector`. Adding the `Conditionable` trait simplifies the example to a nice fluent chain:

```php
seo()
    ->title('Title override')
    ->when($overrideImage, fn ($seo) => $seo->images($overrideImage));
```