### PR TITLE
React inertia + ssr 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.0 - 2025-11-28
+
+- Added the `ExportsArrayMetadata` contract and implemented it across all built-in generators.
+- Exposed `MetadataDirector::toArray()` for exporting structured metadata (useful for Inertia controllers).
+
 ## 2.0.0 - 2025-03-01
 
 - Added support for Laravel 12.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,65 @@ The rendered result will look something like this:
 </script>
 ```
 
+### Exporting metadata as arrays
+
+Every generator now implements the `Honeystone\Seo\Contracts\ExportsArrayMetadata` contract, which means the director
+can provide a structured payload for each generator:
+
+```php
+$seo = seo()->toArray();            // ['meta' => [...], 'twitter' => [...], ...]
+$metaOnly = seo()->toArray('meta'); // limit to a specific generator
+```
+
+This is particularly useful when sharing SEO data with Inertia.js:
+
+```php
+return Inertia::render('Pages/Show', [
+    'page' => $page,
+    'seo' => seo()->toArray(),
+]);
+```
+
+On the client you can decide whether to render the tags yourself, hydrate a preview component, or simply inspect the
+payload for analytics/debugging purposes.
+
+If you are using the bundled `GenerateInertiaMetadata` middleware, the structured payload is automatically shared as
+`$page.props.seoPayload` (alongside the rendered HTML string that remains available under `$page.props.seo` for legacy
+integrations).
+
+### Inertia React
+
+When using Inertia with React, you can render the structured SEO payload directly in the head using the bundled React
+component at `resources/js/inertia/react/SeoHead.tsx`.
+
+1. Register the React-specific middleware `\Honeystone\Seo\Http\Middleware\GenerateInertiaMetadataReact::class` in your
+   Inertia middleware stack so `$page.props.seoPayload` is shared:
+   ```php
+   // app/Http/Middleware/HandleInertiaRequests.php
+   protected $middleware = [
+       // ...
+       \Honeystone\Seo\Http\Middleware\GenerateInertiaMetadataReact::class,
+   ];
+   ```
+2. Render the component in your React layout so every page gets the tags:
+   ```tsx
+   // resources/js/Layouts/AppLayout.tsx
+   import SeoHead from '@/inertia/react/SeoHead';
+
+   export default function AppLayout({ children }) {
+       return (
+           <>
+               <SeoHead defaultTitleSuffix="My App" />
+               {children}
+           </>
+       );
+   }
+   ```
+   The component reads `seoPayload` from `usePage()` and outputs meta, Open Graph, Twitter and JSON-LD tags. Pass
+   `forceNoIndex` if you need to override robots for specific responses.
+
+When using this method, Inertia itself will attempt to replace the meta tags for you so you will need to remove the @metadata blade directive from your layouts. 
+
 ### Default methods
 
 Values provided to default methods will automatically propagate to all configured metadata generators.

--- a/resources/js/inertia/react/SeoHead.tsx
+++ b/resources/js/inertia/react/SeoHead.tsx
@@ -1,0 +1,287 @@
+// resources/js/components/SeoHead.tsx
+import { Head, usePage } from '@inertiajs/react';
+
+type HreflangLink = {
+    href: string;
+    hreflang: string;
+};
+
+type MetaConfig = {
+    title?: string;
+    titleTemplate?: string;
+    description?: string;
+    canonicalEnabled?: boolean;
+};
+
+type MetaData = {
+    title?: string;
+    description?: string;
+    canonical?: string;
+    robots?: string | string[];
+    keywords?: string[];
+    hreflangs?: HreflangLink[];
+    config?: MetaConfig;
+};
+
+type OgImage = {
+    url: string;
+    alt?: string;
+    width?: number;
+    height?: number;
+};
+
+type OpenGraphData = {
+    title?: string;
+    description?: string;
+    type?: string;
+    url?: string;
+    site?: string;
+    locale?: string;
+    images?: (OgImage | string)[];
+};
+
+type TwitterData = {
+    card?: string;
+    site?: string;
+    creator?: string;
+    title?: string;
+    description?: string;
+    image?: string;
+};
+
+type IconLink = {
+    rel: string;
+    href: string;
+    type?: string;
+    sizes?: string;
+};
+
+type JsonLdEntry = {
+    generated?: string;
+    [key: string]: unknown;
+} | string | null;
+
+type SeoObject = {
+    meta?: MetaData;
+    twitter?: TwitterData;
+    ['open-graph']?: OpenGraphData;
+    ['json-ld']?: JsonLdEntry | JsonLdEntry[];
+    icons?: IconLink[];
+};
+
+type SeoHeadProps = {
+    defaultTitleSuffix?: string;
+    forceNoIndex?: boolean;
+};
+
+export default function SeoHead({ defaultTitleSuffix, forceNoIndex = false }: SeoHeadProps) {
+    const { props } = usePage<{ seoPayload?: SeoObject }>();
+    const seo = props.seoPayload;
+
+    if (!seo) {
+        return null;
+    }
+
+    const meta = seo.meta ?? {};
+    const og = (seo['open-graph'] ?? {}) as OpenGraphData;
+    const tw = seo.twitter ?? {};
+    const ld = seo['json-ld'];
+    const icons = seo.icons ?? [];
+
+    const ogImages: OgImage[] = (og.images ?? []).map((image) =>
+        typeof image === 'string'
+            ? { url: image }
+            : image,
+    );
+
+    const template = ''; // meta.config?.titleTemplate;
+    const baseTitle = meta.title ?? og.title ?? tw.title ?? meta.config?.title ?? defaultTitleSuffix;
+    const fullTitle =
+        meta.title && template
+            ? template.replace('{title}', meta.title)
+            : baseTitle;
+
+    const description =
+        meta.description ??
+        og.description ??
+        tw.description ??
+        meta.config?.description ??
+        undefined;
+
+    const canonical = meta.canonical ?? og.url ?? undefined;
+
+    const robotsSource = Array.isArray(meta.robots)
+        ? meta.robots.filter(Boolean).join(', ')
+        : meta.robots;
+
+    const robotsContent = forceNoIndex ? 'noindex,nofollow' : robotsSource ?? undefined;
+
+    const keywords =
+        meta.keywords && meta.keywords.length > 0
+            ? meta.keywords.join(', ')
+            : undefined;
+
+    const jsonLdEntries = Array.isArray(ld) ? ld : ld ? [ld] : [];
+    const jsonLdPayload = jsonLdEntries
+        .map((entry) => {
+            if (!entry) {
+                return null;
+            }
+
+            if (typeof entry === 'string') {
+                return entry;
+            }
+
+            if (typeof entry.generated === 'string') {
+                return entry.generated;
+            }
+
+            const rest = { ...(entry as Record<string, unknown>) };
+            delete rest.config;
+            return JSON.stringify(rest);
+        })
+        .filter(Boolean) as string[];
+
+    return (
+        <Head>
+            {/* ---- BASIC ---- */}
+            {fullTitle && <title>{fullTitle}</title>}
+
+            {description && (
+                <meta name="description" head-key="description" content={description} />
+            )}
+
+            {canonical && (
+                <link rel="canonical" head-key="canonical" href={canonical} />
+            )}
+
+            {robotsContent && (
+                <meta name="robots" content={robotsContent} />
+            )}
+
+            {keywords && (
+                <meta name="keywords" content={keywords} />
+            )}
+
+            {/* ---- HREFLANG ---- */}
+            {meta.hreflangs?.map((link, idx) => (
+                <link
+                    key={`hreflang-${idx}`}
+                    rel="alternate"
+                    hrefLang={link.hreflang}
+                    href={link.href}
+                />
+            ))}
+
+            {/* ---- ICONS / FAVICONS ---- */}
+            {icons.map((icon, idx) => (
+                <link
+                    key={`icon-${idx}`}
+                    rel={icon.rel}
+                    href={icon.href}
+                    type={icon.type}
+                    sizes={icon.sizes}
+                />
+            ))}
+
+            {/* ---- OPEN GRAPH ---- */}
+            {canonical && (
+                <meta property="og:url" content={canonical} />
+            )}
+            {fullTitle && (
+                <meta property="og:title" content={og.title ?? fullTitle} />
+            )}
+            {description && (
+                <meta
+                    property="og:description"
+                    content={og.description ?? description}
+                />
+            )}
+            {og.site && (
+                <meta property="og:site_name" content={og.site} />
+            )}
+            {og.type && (
+                <meta property="og:type" content={og.type} />
+            )}
+            {og.locale && (
+                <meta property="og:locale" content={og.locale} />
+            )}
+
+            {ogImages.map((image, idx) => (
+                <meta
+                    key={`og-image-${idx}`}
+                    property="og:image"
+                    content={image.url}
+                />
+            ))}
+            {ogImages.map((image, idx) =>
+                image.alt ? (
+                    <meta
+                        key={`og-image-alt-${idx}`}
+                        property="og:image:alt"
+                        content={image.alt}
+                    />
+                ) : null
+            )}
+            {ogImages.map((image, idx) =>
+                image.width ? (
+                    <meta
+                        key={`og-image-width-${idx}`}
+                        property="og:image:width"
+                        content={String(image.width)}
+                    />
+                ) : null
+            )}
+            {ogImages.map((image, idx) =>
+                image.height ? (
+                    <meta
+                        key={`og-image-height-${idx}`}
+                        property="og:image:height"
+                        content={String(image.height)}
+                    />
+                ) : null
+            )}
+
+            {/* ---- TWITTER ---- */}
+            <meta
+                name="twitter:card"
+                content={tw.card ?? 'summary_large_image'}
+            />
+            {tw.site && (
+                <meta name="twitter:site" content={tw.site} />
+            )}
+            {tw.creator && (
+                <meta name="twitter:creator" content={tw.creator} />
+            )}
+            {fullTitle && (
+                <meta
+                    name="twitter:title"
+                    content={tw.title ?? fullTitle}
+                />
+            )}
+            {description && (
+                <meta
+                    name="twitter:description"
+                    content={tw.description ?? description}
+                />
+            )}
+            {(tw.image || ogImages[0]) && (
+                <meta
+                    name="twitter:image"
+                    content={tw.image ?? ogImages[0]?.url}
+                />
+            )}
+
+            {/* ---- JSON-LD ---- */}
+            {jsonLdPayload.map((schema, idx) => (
+                <script
+                    key={`ld-json-${idx}`}
+                    type="application/ld+json"
+                    dangerouslySetInnerHTML={{
+                        __html: schema,
+                    }}
+                />
+            ))}
+        </Head>
+    );
+}

--- a/src/Contracts/ExportsArrayMetadata.php
+++ b/src/Contracts/ExportsArrayMetadata.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Honeystone\Seo\Contracts;
+
+/**
+ * Implemented by metadata generators that can expose their payload as an array.
+ */
+interface ExportsArrayMetadata
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+}
+

--- a/src/Generators/JsonLdGenerator.php
+++ b/src/Generators/JsonLdGenerator.php
@@ -7,6 +7,7 @@ namespace Honeystone\Seo\Generators;
 use Honeystone\Seo\Concerns\HasConfig;
 use Honeystone\Seo\Concerns\HasData;
 use Honeystone\Seo\Concerns\HasDefaults;
+use Honeystone\Seo\Contracts\ExportsArrayMetadata;
 use Honeystone\Seo\Contracts\GeneratesMetadata;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Str;
@@ -28,7 +29,7 @@ use function sprintf;
 use function url;
 use function view;
 
-final class JsonLdGenerator implements GeneratesMetadata
+final class JsonLdGenerator implements GeneratesMetadata, ExportsArrayMetadata
 {
     use HasConfig, HasData, HasDefaults;
 
@@ -242,7 +243,7 @@ final class JsonLdGenerator implements GeneratesMetadata
         return $this;
     }
 
-    public function generate(): View
+    public function toArray(): array
     {
         $this->checkExpectations();
 
@@ -252,7 +253,12 @@ final class JsonLdGenerator implements GeneratesMetadata
             $this->generateJsonLd($data) :
             '';
 
-        return view('honeystone-seo::json-ld', compact('generated') + $data);
+        return compact('generated') + $data;
+    }
+
+    public function generate(): View
+    {
+        return view('honeystone-seo::json-ld', $this->toArray());
     }
 
     /**

--- a/src/Generators/MetaGenerator.php
+++ b/src/Generators/MetaGenerator.php
@@ -7,6 +7,7 @@ namespace Honeystone\Seo\Generators;
 use Honeystone\Seo\Concerns\HasConfig;
 use Honeystone\Seo\Concerns\HasData;
 use Honeystone\Seo\Concerns\HasDefaults;
+use Honeystone\Seo\Contracts\ExportsArrayMetadata;
 use Honeystone\Seo\Contracts\GeneratesMetadata;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Str;
@@ -14,7 +15,7 @@ use Illuminate\Support\Str;
 use function array_merge;
 use function view;
 
-final class MetaGenerator implements GeneratesMetadata
+final class MetaGenerator implements GeneratesMetadata, ExportsArrayMetadata
 {
     use HasConfig, HasData, HasDefaults;
 
@@ -110,6 +111,13 @@ final class MetaGenerator implements GeneratesMetadata
         $this->custom[] = [$property => $content];
 
         return $this;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'custom' => array_merge($this->config['custom'] ?? [], $this->custom),
+        ] + $this->getData();
     }
 
     public function generate(): View

--- a/src/Generators/OpenGraphGenerator.php
+++ b/src/Generators/OpenGraphGenerator.php
@@ -7,6 +7,7 @@ namespace Honeystone\Seo\Generators;
 use Honeystone\Seo\Concerns\HasConfig;
 use Honeystone\Seo\Concerns\HasData;
 use Honeystone\Seo\Concerns\HasDefaults;
+use Honeystone\Seo\Contracts\ExportsArrayMetadata;
 use Honeystone\Seo\Contracts\GeneratesMetadata;
 use Honeystone\Seo\OpenGraph\AudioProperties;
 use Honeystone\Seo\OpenGraph\Contracts\Taggable;
@@ -22,7 +23,7 @@ use function in_array;
 use function seo;
 use function view;
 
-final class OpenGraphGenerator implements GeneratesMetadata
+final class OpenGraphGenerator implements GeneratesMetadata, ExportsArrayMetadata
 {
     use HasConfig, HasData, HasDefaults;
 
@@ -209,13 +210,18 @@ final class OpenGraphGenerator implements GeneratesMetadata
         return $this;
     }
 
-    public function generate(): View
+    public function toArray(): array
     {
         $this->syncTags();
 
-        return view('honeystone-seo::open-graph', [
+        return [
             'custom' => array_merge($this->config['custom'] ?? [], $this->custom),
-        ] + $this->getData());
+        ] + $this->getData();
+    }
+
+    public function generate(): View
+    {
+        return view('honeystone-seo::open-graph', $this->toArray());
     }
 
     private function syncTags(): void

--- a/src/Generators/TwitterGenerator.php
+++ b/src/Generators/TwitterGenerator.php
@@ -7,6 +7,7 @@ namespace Honeystone\Seo\Generators;
 use Honeystone\Seo\Concerns\HasConfig;
 use Honeystone\Seo\Concerns\HasData;
 use Honeystone\Seo\Concerns\HasDefaults;
+use Honeystone\Seo\Contracts\ExportsArrayMetadata;
 use Honeystone\Seo\Contracts\GeneratesMetadata;
 use Honeystone\Seo\Twitter\Contracts\Card;
 use Illuminate\Contracts\View\View;
@@ -14,7 +15,7 @@ use Illuminate\Support\Arr;
 
 use function view;
 
-final class TwitterGenerator implements GeneratesMetadata
+final class TwitterGenerator implements GeneratesMetadata, ExportsArrayMetadata
 {
     use HasConfig, HasData, HasDefaults;
 
@@ -87,6 +88,11 @@ final class TwitterGenerator implements GeneratesMetadata
         $this->data('imageAlt', $alt);
 
         return $this->data(__FUNCTION__, $value);
+    }
+
+    public function toArray(): array
+    {
+        return $this->getData();
     }
 
     public function generate(): View

--- a/src/Http/Middleware/GenerateInertiaMetadata.php
+++ b/src/Http/Middleware/GenerateInertiaMetadata.php
@@ -20,7 +20,6 @@ final class GenerateInertiaMetadata
     {
         // @phpstan-ignore-next-line
         Inertia::share('seo', static fn (): string => (string) seo()->generate());
-        Inertia::share('seoPayload', static fn (): array => seo()->toArray());
 
         return $next($request);
     }

--- a/src/Http/Middleware/GenerateInertiaMetadataReact.php
+++ b/src/Http/Middleware/GenerateInertiaMetadataReact.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Honeystone\Seo\Http\Middleware;
 
 use Closure;
@@ -11,17 +9,16 @@ use Symfony\Component\HttpFoundation\Response;
 
 use function seo;
 
-final class GenerateInertiaMetadata
+final class GenerateInertiaMetadataReact
 {
     /**
      * @param Closure(Request): (Response) $next
      */
     public function handle(Request $request, Closure $next): Response
     {
-        // @phpstan-ignore-next-line
-        Inertia::share('seo', static fn (): string => (string) seo()->generate());
         Inertia::share('seoPayload', static fn (): array => seo()->toArray());
 
         return $next($request);
     }
 }
+

--- a/src/MetadataDirector.php
+++ b/src/MetadataDirector.php
@@ -7,6 +7,7 @@ namespace Honeystone\Seo;
 use Honeystone\Seo\Concerns\HasConfig;
 use Honeystone\Seo\Concerns\HasDefaults;
 use Honeystone\Seo\Contracts\BuildsMetadata;
+use Honeystone\Seo\Contracts\ExportsArrayMetadata;
 use Honeystone\Seo\Contracts\GeneratesMetadata;
 use Honeystone\Seo\Contracts\RegistersGenerators;
 use Illuminate\Contracts\Config\Repository;
@@ -24,13 +25,18 @@ use function str_replace;
 use function trim;
 use function view;
 
-final class MetadataDirector implements BuildsMetadata
+final class MetadataDirector implements BuildsMetadata, ExportsArrayMetadata
 {
     use Conditionable;
     use HasConfig {
         config as private setConfig;
     }
     use HasDefaults;
+
+    /**
+     * @var array<string, GeneratesMetadata>
+     */
+    protected array $generators = [];
 
     public function __construct(
         private readonly RegistersGenerators $register,
@@ -39,6 +45,8 @@ final class MetadataDirector implements BuildsMetadata
         $this->config = $config !== null ?
             $config->get('honeystone-seo') :
             [];
+
+        $this->syncGenerators();
     }
 
     /**
@@ -156,11 +164,21 @@ final class MetadataDirector implements BuildsMetadata
 
     public function generator(string $name): GeneratesMetadata
     {
-        return $this->register->get($name);
+        $generator = $this->register->get($name);
+
+        $this->generators[$name] = $generator;
+
+        return $generator;
     }
 
     public function generate(string ...$only): View
     {
+        $this->syncGenerators();
+
+        $generators = count($only) > 0 ?
+            $this->register->only($only) :
+            $this->generators;
+
         $generated = implode(
             "\n    ",
             array_filter(array_map(
@@ -168,9 +186,7 @@ final class MetadataDirector implements BuildsMetadata
                     /** @phpstan-ignore-next-line */
                     (string) $generator->generate(),
                 ),
-                count($only) > 0 ?
-                    $this->register->only($only) :
-                    $this->register->all(),
+                $generators,
             )),
         );
 
@@ -200,15 +216,43 @@ final class MetadataDirector implements BuildsMetadata
 
     private function propagateConfig(): void
     {
-        foreach ($this->register->all() as $generator) {
+        $this->syncGenerators();
+
+        foreach ($this->generators as $generator) {
             $generator->config($this->getConfig('generators.'.$generator::class, []));
         }
     }
 
     private function propagateDefaults(): void
     {
-        foreach ($this->register->all() as $generator) {
+        $this->syncGenerators();
+
+        foreach ($this->generators as $generator) {
             $generator->defaults($this->defaults);
         }
+    }
+
+    public function toArray(?string $only = null): array
+    {
+        $this->syncGenerators();
+
+        $result = [];
+
+        foreach ($this->generators as $name => $generator) {
+            if ($only !== null && $name !== $only) {
+                continue;
+            }
+
+            if ($generator instanceof ExportsArrayMetadata) {
+                $result[$name] = $generator->toArray();
+            }
+        }
+
+        return $result;
+    }
+
+    private function syncGenerators(): void
+    {
+        $this->generators = $this->register->all();
     }
 }

--- a/tests/Integration/MetadataTest.php
+++ b/tests/Integration/MetadataTest.php
@@ -25,6 +25,35 @@ beforeEach(function (): void {
         ->url('https://mywebsite.com');
 });
 
+it('exports generator payloads as arrays', function (): void {
+
+    seo()
+        ->title('Foo', template: false)
+        ->description('Bar')
+        ->images('https://mywebsite.com/pic.png')
+        ->twitterEnabled(true);
+
+    $payload = seo()->toArray();
+
+    expect($payload)
+        ->toHaveKeys(['meta', 'twitter', 'open-graph', 'json-ld'])
+        ->and($payload['meta']['title'])->toBe('Foo')
+        ->and($payload['twitter']['enabled'])->toBeTrue()
+        ->and($payload['open-graph']['images'])->toEqual(['https://mywebsite.com/pic.png'])
+        ->and($payload['json-ld']['generated'])->not->toBe('');
+});
+
+it('filters generator payloads when exporting a specific generator', function (): void {
+
+    seo()->title('Foo', template: false);
+
+    $payload = seo()->toArray('meta');
+
+    expect($payload)
+        ->toHaveKey('meta')
+        ->and($payload)->not->toHaveKey('twitter');
+});
+
 it('propagates the default locale', function (): void {
 
     seo()->locale('Foo');


### PR DESCRIPTION
Hi there,

Love this library, but the support for React + Inertia, especially using SSR has caused me some trouble recently. 

When using the `@metadata` tag AND a custom `<Head>`, Inertia will fail to update all the tags correctly. Inertia suggests you use head-key, but this is cumbersome and kinda sucks updating all the blade files to support it.

This approach does away with `@metadata` for react projects and replaces it with a dynamically built `<SeoHead>` component and React middleware. 

* add toArray for all generators
* test for array output of seo data
* add react output SeoHead component 
* add seo values in new middleware
